### PR TITLE
chore: disable gno-by-example

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
 from = "/*"
-to = "/index.html"
-status = 200
+to = "https://docs.gno.land"
+status = 302


### PR DESCRIPTION
- The quality is low, there is no call to action, it is outdated, and it has limited use.
-  We don't have time to update it.
-  It competes with the essential docs/tools/onboarding flows.

We will disable it until we are ready to recycle it later.