### PR TITLE
chore: force redirect to docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [[redirects]]
 from = "/*"
 to = "https://docs.gno.land"
+force = true
 status = 302


### PR DESCRIPTION
## Description

Should force redirect to the docs website, which isn't the case right now